### PR TITLE
Update plugin.php

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -21,7 +21,7 @@
 
 define( 'WAPSTO_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 
-function change_product_data_store( &$stores ) {
+function change_product_data_store( $stores ) {
 
 	if ( ! class_exists( 'SE_WC_Product_Data_Store_CPT' ) ) {
 		require_once( WAPSTO_PLUGIN_PATH . 'data-stores/class-se-wc-product-data-store-cpt.php' );


### PR DESCRIPTION
function change_product_data_store( &$stores ) >> remove '&' for working on Wordpress 5.7 and PHP 7.4.16