### PR TITLE
Update class-se-wc-product-data-store-cpt.php

### DIFF
--- a/data-stores/class-se-wc-product-data-store-cpt.php
+++ b/data-stores/class-se-wc-product-data-store-cpt.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class SE_WC_Product_Data_Store_CPT extends WC_Product_Data_Store_CPT {
 
-	public function search_products( $term, $type = '', $include_variations = false, $all_statuses = false ) {
+	public function search_products( $term, $type = '', $include_variations = false, $all_statuses = false, $limit = NULL, $include = NULL, $exclude = NULL ) {
 		global $wpdb;
 
 		$like_term     = '%' . $wpdb->esc_like( $term ) . '%';


### PR DESCRIPTION
SE_WC_Product_Data_Store_CPT::search_products($term, $type = '', $include_variations = false, $all_statuses = false) should be compatible with WC_Product_Data_Store_CPT::search_products($term, $type = '', $include_variations = false, $all_statuses = false, $limit = NULL, $include = NULL, $exclude = NULL)

Tested on Woocommerce 5.1.0